### PR TITLE
Adding a simple CMakeLists.txt to use this project on CMake based projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ FFX_CAS/cas-samples/bin/
 FFX_CAS/cas-samples/build/DX12/
 
 FFX_CAS/cas-samples/build/VK/
+
+# CMake Default Builder Directory
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22)
+project(FidelityFX-CAS VERSION 1.0.2)
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_include_directories(${PROJECT_NAME} INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/ffx-cas>
+)
+
+install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}_TARGETS
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    PUBLIC_HEADER DESTINATION include
+)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/ffx-cas DESTINATION include)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ include(FetchContent)
 FetchContent_Declare(
   ffx-cas
   GIT_REPOSITORY https://github.com/arthurafarias/FidelityFX-CAS.git
-  GIT_TAG        3a89494e45ccac621fbf10c8f72a62fc0c182d8b
+  GIT_TAG        61fd4a02976a77fc57b3d4263fbed2a4e58ffb31
 )
 
 FetchContent_MakeAvailable(ffx-cas)

--- a/README.md
+++ b/README.md
@@ -48,3 +48,45 @@ You can find the documentation for the CAS algorithm and how to implement it usi
 ## Command Line Tool
 
 There is also a command line tool to allow you to test the effects of FidelityFX CAS on standalone image files such as screenshots from your game, allowing you to evaluate it before integration. Please see the [FidelityFX-CLI](https://github.com/GPUOpen-Effects/FidelityFX-CLI) project for more details.
+
+## How to use this project with CMAKE
+
+Here is an example of using this project with cmake using the following structure
+
+```tree
+.
+├── CMakeLists.txt
+├── include
+└── src
+    └── main.cpp
+```
+
+CMakeLists.txt
+```cmake
+cmake_minimum_required(VERSION 3.22)
+project(fidelifyfx-cas-baseproject VERSION 0.1)
+
+include(FetchContent)
+
+FetchContent_Declare(
+  ffx-cas
+  GIT_REPOSITORY https://github.com/arthurafarias/FidelityFX-CAS.git
+  GIT_TAG        3a89494e45ccac621fbf10c8f72a62fc0c182d8b
+)
+
+FetchContent_MakeAvailable(ffx-cas)
+
+add_executable(${PROJECT_NAME} src/main.cpp)
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${ffx-cas_SOURCE_DIR})
+```
+
+src/main.c
+```c
+#include "ffx-cas/ffx_a.h"
+
+int main(int argc, char* argv[])
+{
+    return 0;
+}
+```


### PR DESCRIPTION
I've wrote a simple CMake file to the project in order to avoid copying the source to the project tree and referencing it directly to the github repository.

Here is a description on how to use it:

Here is an example of using this project with cmake using the following structure

```tree
.
├── CMakeLists.txt
├── include
└── src
    └── main.cpp
```

CMakeLists.txt
```cmake
cmake_minimum_required(VERSION 3.22)
project(fidelifyfx-cas-baseproject VERSION 0.1)

include(FetchContent)

FetchContent_Declare(
  ffx-cas
  GIT_REPOSITORY https://github.com/arthurafarias/FidelityFX-CAS.git
  GIT_TAG        61fd4a02976a77fc57b3d4263fbed2a4e58ffb31
)

FetchContent_MakeAvailable(ffx-cas)

add_executable(${PROJECT_NAME} src/main.cpp)

target_include_directories(${PROJECT_NAME} PUBLIC ${ffx-cas_SOURCE_DIR})
```

src/main.c
```c
#include "ffx-cas/ffx_a.h"

int main(int argc, char* argv[])
{
    return 0;
}
```